### PR TITLE
chore: prep release 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog for RQ Metrics
+
+## [0.0.1](https://github.com/SwissDataScienceCenter/renku/releases/tag/0.0.1) (2022-03-14)
+
+First release, with support for a HA Redis with a sentinel.


### PR DESCRIPTION
This was the main problem why the new deployment failed. The renku-core chart has `latest` hardcoded as the image for the metrics here. But we never did a release and published the image.

The actions are setup so that a semver release like x.x.x will result in also tagging `latest`.

So after this we should just enable the metrics in all the deployments.

I tested that when this new image of the metrics is used renku-core comes up without a problem

Also port-forwarding (`kubectl port-forward tasko-renku-core-v9-8484bb4767-q25rj 8765`) and hitting the renku-core pod on 8765 shows a sensible result:
```
 curl 'http://localhost:8765/api/v1/query?query=up&time=2015-07-01T20:10:51.781Z'
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 347.0
python_gc_objects_collected_total{generation="1"} 53.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
...
```

So after this is merged I will make a release. And go through the renku charts to update the appropriate stuff.